### PR TITLE
INF-1055 normalize DNS names

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,22 +3,22 @@ base = ""
 publish = "build/site"
 command = "npm i @antora/cli @antora/site-generator-default && $(npm bin)/antora --fetch antora-playbook.yml"
 
-# Rewrite to sdk-ext for fetchings artifacts
+# Rewrite to sdk.dfinity.systems for fetchings artifacts
 [[redirects]]
 from = "/install.sh"
-to = "https://sdk-ext.dfinity.systems/install.sh"
+to = "https://sdk.dfinity.systems/install.sh"
 status = 200
 
-# Rewrite to sdk-ext for fetchings artifacts
+# Rewrite to sdk.dfinity.systems for fetchings artifacts
 [[redirects]]
 from = "/manifest.json"
-to = "https://sdk-ext.dfinity.systems/manifest.json"
+to = "https://sdk.dfinity.systems/manifest.json"
 status = 200
 
-# Rewrite to sdk-ext for fetchings artifacts
+# Rewrite to sdk.dfinity.systems for fetchings artifacts
 [[redirects]]
 from = "/downloads/*"
-to = "https://sdk-ext.dfinity.systems/downloads/:splat"
+to = "https://sdk.dfinity.systems/downloads/:splat"
 status = 200
 
 # update base url to docs


### PR DESCRIPTION
In the process of normalizing the DNS names we use for our (Infra)
deployments, we're renaming sdk-ext.dfinity.systems to
sdk.dfinity.systems. The old new will continue to function for a while.

This change switches the netlify deployment to redirect to the new name.