### PR TITLE
INF-1161: rewrite SDK paths to our new CDN

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,23 +3,23 @@ base = ""
 publish = "build/site"
 command = "npm i @antora/cli @antora/site-generator-default && $(npm bin)/antora --fetch antora-playbook.yml"
 
-# Rewrite to sdk.dfinity.systems for fetchings artifacts
+# Rewrite to download.dfinity.systems for fetchings artifacts
 [[redirects]]
 from = "/install.sh"
-to = "https://sdk.dfinity.systems/install.sh"
-status = 200
+to = "https://download.dfinity.systems/sdk/install.sh"
+status = 301
 
-# Rewrite to sdk.dfinity.systems for fetchings artifacts
+# Rewrite to download.dfinity.systems for fetchings artifacts
 [[redirects]]
 from = "/manifest.json"
-to = "https://sdk.dfinity.systems/manifest.json"
-status = 200
+to = "https://download.dfinity.systems/sdk/manifest.json"
+status = 301
 
-# Rewrite to sdk.dfinity.systems for fetchings artifacts
+# Rewrite to download.dfinity.systems for fetchings artifacts
 [[redirects]]
 from = "/downloads/*"
-to = "https://sdk.dfinity.systems/downloads/:splat"
-status = 200
+to = "https://download.dfinity.systems/sdk/:splat"
+status = 301
 
 # update base url to docs
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,19 +7,19 @@ command = "npm i @antora/cli @antora/site-generator-default && $(npm bin)/antora
 [[redirects]]
 from = "/install.sh"
 to = "https://download.dfinity.systems/sdk/install.sh"
-status = 301
+status = 302
 
 # Rewrite to download.dfinity.systems for fetchings artifacts
 [[redirects]]
 from = "/manifest.json"
 to = "https://download.dfinity.systems/sdk/manifest.json"
-status = 301
+status = 302
 
 # Rewrite to download.dfinity.systems for fetchings artifacts
 [[redirects]]
 from = "/downloads/*"
 to = "https://download.dfinity.systems/sdk/:splat"
-status = 301
+status = 302
 
 # update base url to docs
 [[redirects]]


### PR DESCRIPTION
The SDK release artefacts are now published to a CDN ensuring fast
downloads for our users. See: https://github.com/dfinity-lab/sdk/pull/492

To make use of this CDN the sdk.dfinity.org site needs to
redirect (301) to the CDN at https://download.dfinity.systems.
This commit configures the following redirects:

* https://sdk.dfinity.org/install.sh → https://download.dfinity.systems/sdk/install.sh

* https://sdk.dfinity.org/manifest.json → https://download.dfinity.systems/sdk/manifest.json

* https://sdk.dfinity.org/downloads/dfx/* → https://download.dfinity.systems/sdk/dfx/*

Note that it's important not to use the 200 code since that will
instruct Netlify to proxy instead of redirect which will defeat the
purpose of the CDN.